### PR TITLE
Rename gdeltloader -> gdelttools

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ These are the steps I performed to grab data from the main GDELT dataset, import
     I used [gdelttools](https://github.com/jdrumgoole/gdelttools) to do this. Once you've cloned the gdelttools repo, navigate to that directory and run the following command:
 
     ```python
-    python gdeltloader\gdeltloader.py --ziplist master
+    python gdelttools\gdeltloader.py --ziplist master
     ```
 
 2. Reduce main file to the amount of days you want (number passed to the `tail` command) and only export archives. I went with `120` days:


### PR DESCRIPTION
In this project's README.md, you are directed to clone https://github.com/jdrumgoole/gdelttools and then run the following from the directory:

`python gdeltloader\gdeltloader.py --ziplist master`

Problem is, that folder appears to have been renamed and is now `gdelttools`. So if you run this command as-is, you will get:

`Python: can't open file 'gdeltloadergdeltloader.py': [Errno 2] No such file or directory`

This PR simply renames the referenced folder.

(Note that you will get that same error again even with this PR's fixes because of the `\` vs. `/` after, at least on macOS Catalina, but I'm not sure if the Windows-style slash was done on purpose, so that's not included in this PR.)

You then get further problems, but that seems to be an issue with the upstream repo, not the docs. :) I'll handle that over at https://github.com/jdrumgoole/gdelttools/issues/1